### PR TITLE
srt: genereate unique name for backup file

### DIFF
--- a/pysrt/commands.py
+++ b/pysrt/commands.py
@@ -177,9 +177,12 @@ class SubRipShifter(object):
             part_file.save(path=file_name, encoding=self.output_encoding)
 
     def create_backup(self):
+        backup_idx = 1
         backup_file = self.arguments.file + self.BACKUP_EXTENSION
-        if not os.path.exists(backup_file):
-            shutil.copy2(self.arguments.file, backup_file)
+        while os.path.exists(backup_file):
+            backup_file = self.arguments.file + ('.%i' % backup_idx) + self.BACKUP_EXTENSION
+            backup_idx += 1
+        shutil.copy2(self.arguments.file, backup_file)
         self.output_file_path = self.arguments.file
         self.arguments.file = backup_file
 


### PR DESCRIPTION
If .bak file exist, then its contents are taken as the source file.

reproducing the error situation
```
# source file contents
$ cat 1.srt
1
00:00:01,111 --> 00:00:03,646
Line 1

2
00:00:07,569 --> 00:00:10,058
Line 2

# good
$ srt -i shift -10ms 1.srt && cat 1.srt
1
00:00:01,101 --> 00:00:03,636
Line 1

2
00:00:07,559 --> 00:00:10,048
Line 2

# fail
$ srt -i shift -10ms 1.srt && cat 1.srt
1
00:00:01,101 --> 00:00:03,636
Line 1

2
00:00:07,559 --> 00:00:10,048
Line 2

# fail
$ srt -i shift -20ms 1.srt && cat 1.srt
1
00:00:01,091 --> 00:00:03,626
Line 1

2
00:00:07,549 --> 00:00:10,038
Line 2
```
My solution is generate unique name for bak file.